### PR TITLE
Debugging freshwater

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -123,9 +123,10 @@ async function send_danswer_request(
 }
 
 export default async function middleware(req, res, next) {
-  const path = req.url.replace('/_da/', '/');
-  path.replace('/freshwater/', '/');
-  path.replace('/marine/', '/');
+  const path = req.url
+    .replace('/_da/', '/')
+    .replace('/freshwater/', '/')
+    .replace('/marine/', '/');
 
   const reqUrl = `${process.env.DANSWER_URL}/api${path}`;
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -124,6 +124,8 @@ async function send_danswer_request(
 
 export default async function middleware(req, res, next) {
   const path = req.url.replace('/_da/', '/');
+  path.replace('/freshwater/', '/');
+  path.replace('/marine/', '/');
 
   const reqUrl = `${process.env.DANSWER_URL}/api${path}`;
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -123,10 +123,7 @@ async function send_danswer_request(
 }
 
 export default async function middleware(req, res, next) {
-  const path = req.url
-    .replace('/_da/', '/')
-    .replace('/freshwater/', '/')
-    .replace('/marine/', '/');
+  const path = req.url.replace(/^.*(?=\/persona)/, '');
 
   const reqUrl = `${process.env.DANSWER_URL}/api${path}`;
 


### PR DESCRIPTION
I removed everything before /persona because it fails on websites started on relative path.

`https://demo-water.devel5cph.eea.europa.eu/_da/persona/27
 -> {"error_type": "NotFound"}`

The previous link should result in `https://gptlab.eea.europa.eu/api/persona/27` but something appears between `api/` and `persona/` and returns Not found

Task: https://taskman.eionet.europa.eu/issues/288984
